### PR TITLE
reports: Refactoring

### DIFF
--- a/Orange/canvas/report/__init__.py
+++ b/Orange/canvas/report/__init__.py
@@ -237,10 +237,19 @@ def describe_data(data):
     return items
 
 
-def describe_data_brief(data):
-    domain = data.domain
+def describe_domain_brief(domain):
+    """
+    Return an :obj:`OrderedDict` with the number of features, metas and classes
+
+    Description contains "Features" and "Meta attributes" with the number of
+    featuers, and "Targets" that contains either a name, if there is a single
+    target, or the number of targets if there are multiple.
+
+    :param domain: data
+    :type domain: Orange.data.Domain
+    :rtype: OrderedDict
+    """
     items = OrderedDict([
-        ("Data instances", len(data)),
         ("Features", len(domain.attributes) or "None"),
         ("Meta attributes", len(domain.metas) or "None")])
     if domain.has_discrete_class:
@@ -252,4 +261,23 @@ def describe_data_brief(data):
         items["Targets"] = len(domain.class_vars)
     else:
         items["Targets"] = False
+    return items
+
+
+def describe_data_brief(data):
+    """
+    Return an :obj:`OrderedDict` with a brief description of data.
+
+    Description contains keys "Data instances" with the number of instances,
+    "Features" and "Meta attributes" with the corresponding numbers, and
+    "Targets", which contains a name, if there is a single target, or the
+    number of targets if there are multiple.
+
+    :param data: data
+    :type data: Orange.data.Table
+    :rtype: OrderedDict
+    """
+    items = OrderedDict()
+    items["Data instances"] = len(data)
+    items.update(describe_domain_brief(data.domain))
     return items

--- a/Orange/canvas/report/__init__.py
+++ b/Orange/canvas/report/__init__.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import time
 import itertools
 import time
 from PyQt4.QtCore import QByteArray, QBuffer, QIODevice

--- a/Orange/canvas/report/__init__.py
+++ b/Orange/canvas/report/__init__.py
@@ -1,23 +1,84 @@
+from collections import OrderedDict
+import time
 import itertools
 import time
 from PyQt4.QtCore import QByteArray, QBuffer, QIODevice
 from Orange.widgets.io import PngFormat
 
 
-def plural(s, number):
-    return s.format(number=number, s="s" if number % 100 != 1 else "")
+def plural(s, number, suffix="s"):
+    """
+    Insert the number into the string, and make plural where marked, if needed.
+
+    The string should use `{number}` to mark the place(s) where the number is
+    inserted and `{s}` where an "s" needs to be added if the number is not 1.
+
+    For instance, a string could be "I saw {number} dog{s} in the forest".
+
+    Argument `suffix` can be used for some forms or irregular plural, like:
+
+        plural("I saw {number} fox{s} in the forest", x, "es")
+        plural("I say {number} child{s} in the forest", x, "ren")
+
+    :param s: string
+    :type s: str
+    :param number: number
+    :type number: int
+    :param suffix: the suffix to use; default is "s"
+    :type suffix: str
+    :rtype: str
+    """
+    return s.format(number=number, s=suffix if number % 100 != 1 else "")
 
 
-def plural_w(s, number, capitalize=False):
+def plural_w(s, number, suffix="s", capitalize=False):
+    """
+    Insert the number into the string, and make plural where marked, if needed.
+
+    If the number is smaller or equal to ten, a word is used instead of a
+    numeric representation.
+
+    The string should use `{number}` to mark the place(s) where the number is
+    inserted and `{s}` where an "s" needs to be added if the number is not 1.
+
+    For instance, a string could be "I saw {number} dog{s} in the forest".
+
+    Argument `suffix` can be used for some forms or irregular plural, like:
+
+        plural("I saw {number} fox{s} in the forest", x, "es")
+        plural("I say {number} child{s} in the forest", x, "ren")
+
+    :param s: string
+    :type s: str
+    :param number: number
+    :type number: int
+    :param suffix: the suffix to use; default is "s"
+    :type suffix: str
+    :rtype: str
+    """
     numbers = ("zero", "one", "two", "three", "four", "five", "six", "seven",
                "nine", "ten")
     number_str = numbers[number] if number < len(numbers) else str(number)
     if capitalize:
         number_str = number_str.capitalize()
-    return s.format(number=number_str, s="s" if number % 100 != 1 else "")
+    return s.format(number=number_str, s=suffix if number % 100 != 1 else "")
 
 
 def clip_string(s, limit=1000, sep=None):
+    """
+    Clip a string at a given character and add "..." if the string was clipped.
+
+    If a separator is specified, the string is not clipped at the given limit
+    but after the last occurence of the separator below the limit.
+
+    :param s: string to clip
+    :type s: str
+    :param limit: number of characters to retain (including "...")
+    :type limit: int
+    :param sep: separator
+    :type sep: str
+    :rtype: str
+    """
     if len(s) < limit:
         return s
     s = s[:limit - 3]
@@ -29,25 +90,95 @@ def clip_string(s, limit=1000, sep=None):
     return s[:sep_pos + len(sep)] + "..."
 
 
-def clipped_list(s, limit=1000, less_lookups=False):
+def clipped_list(items, limit=1000, less_lookups=False, total_min=10, total=""):
+    """
+    Return a clipped comma-separated representation of the list.
+
+    If `less_lookups` is `True`, clipping will use a generator across the first
+    `(limit + 2) // 3` items only, which suffices even if each item is only a
+    single character long. This is useful in case when retrieving items is
+    expensive, while it is generally slower.
+
+    If there are at least `total_lim` items, and argument `total` is present,
+    the string `total.format(len(items))` is added to the end of string.
+    Argument `total` can be, for instance `"(total: {} variables)"`.
+
+    If `total` is given, `s` cannot be a generator.
+
+    :param items: list
+    :type items: list or another iterable object
+    :param limit: number of characters to retain (including "...")
+    :type limit: int
+    :param total_min: the minimal number of items that triggers adding `total`
+    :type total_min: int
+    :param total: the string that is added if `len(items) >= total_min`
+    :type total: str
+    :param less_lookups: minimize the number of lookups
+    :type less_lookups: bool
+    :return:
+    """
     if less_lookups:
-        s = ", ".join(itertools.islice(s, (limit + 2) // 3))
+        s = ", ".join(itertools.islice(items, (limit + 2) // 3))
     else:
-        s = ", ".join(s)
-    return clip_string(s, limit, ", ")
+        s = ", ".join(items)
+    s = clip_string(s, limit, ", ")
+    if total and len(items) >= total_min:
+        s += " " + total.format(len(items))
+    return s
 
 
 def get_html_section(name):
+    """
+    Return a new section as HTML, with the given name and a time stamp.
+
+    :param name: section name
+    :type name: str
+    :rtype: str
+    """
     datetime = time.strftime("%a %b %d %y, %H:%M:%S")
-    return "<h1>%s <span class='timestamp'>%s</h1>" % (name, datetime)
+    return "<h1>{} <span class='timestamp'>{}</h1>".format(name, datetime)
 
 
 def get_html_subsection(name):
-    return "<h2>%s</h2>" % name
+    """
+    Return a subsection as HTML, with the given name
+
+    :param name: subsection name
+    :type name: str
+    :rtype: str
+    """
+    return "<h2>{}</h2>".format(name)
 
 
-def render_items(items):
-    return "<ul>" + "".join("<b>%s:</b> %s</br>" % i for i in items) + "</ul>"
+def render_items(items, order=None, exclude=None):
+    """
+    Render a list of pairs or an (ordered) dictionary as a HTML list.
+
+    The function skips the items whose values are `None` or `False`, and items
+    that are listed in `exclude`.
+
+    If argument `order` is present, the items must be given as dictionary.
+
+    :param items: a list or dictionary of items
+    :type items: dict or list
+    :param order: a list of item names to render
+    :type order: list
+    :param exclude: a list or set of items to exclude
+    :type exclude: list or set
+    :return: rendered content
+    :rtype: str
+    """
+    if order is not None:
+        gen = ((key, items[key]) for key in order)
+    elif isinstance(items, dict):
+        gen = items.items()
+    else:
+        gen = items
+    return "<ul>" + "".join(
+        "<b>{}:</b> {}</br>".format(key, value) for key, value in gen
+        if (exclude is None or key not in exclude) and
+        (value is not None and value is not False)
+    ) + "</ul>"
 
 
 def get_html_img(scene):
@@ -58,3 +189,67 @@ def get_html_img(scene):
     writer.write(filename, scene)
     img_encoded = byte_array.toBase64().data().decode("utf-8")
     return "<ul><img src='data:image/png;base64,%s'/></ul>" % img_encoded
+
+
+def describe_domain(domain):
+    """
+    Return an :obj:`OrderedDict` describing a domain
+
+    Description contains keys "Features", "Meta attributes" and "Targets"
+    with the corresponding clipped lists of names. If the domain contains no
+    meta attributes or targets, the value is `False`, which prevents it from
+    being rendered by :obj:`~Orange.canvas.report.render_items`.
+
+    :param domain: domain
+    :type domain: Orange.data.Domain
+    :rtype: OrderedDict
+    """
+    def clip_attrs(items, s):
+        return clipped_list([a.name for a in items], 1000,
+                            total_min=10, total=" (total: {{}} {})".format(s))
+
+    return OrderedDict(
+        [("Features", clip_attrs(domain.attributes, "features")),
+         ("Meta attributes", bool(domain.metas) and
+             clip_attrs(domain.metas, "meta attributes")),
+         ("Target", bool(domain.class_vars) and
+             clip_attrs(domain.class_vars, "targets variables"))])
+
+
+def describe_data(data):
+    """
+    Return an :obj:`OrderedDict` describing the data
+
+    Description contains keys "Data instances" (with the number of instances)
+    and "Features", "Meta attributes" and "Targets" with the corresponding
+    clipped lists of names. If the domain contains no meta attributes or
+    targets, the value is `False`, which prevents it from being rendered.
+
+    :param data: data
+    :type data: Orange.data.Table
+    :rtype: OrderedDict
+    """
+    if data is None:
+        return OrderedDict()
+    items = OrderedDict()
+    items["Data instances"] = len(data)
+    items.update(describe_domain(data.domain))
+    return items
+
+
+def describe_data_brief(data):
+    domain = data.domain
+    items = OrderedDict([
+        ("Data instances", len(data)),
+        ("Features", len(domain.attributes) or "None"),
+        ("Meta attributes", len(domain.metas) or "None")])
+    if domain.has_discrete_class:
+        items["Target"] = "Class '{}'".format(domain.class_var.name)
+    elif domain.has_continuous_class:
+        items["Target"] = "Numeric variable '{}'". \
+            format(domain.class_var.name)
+    elif domain.class_vars:
+        items["Targets"] = len(domain.class_vars)
+    else:
+        items["Targets"] = False
+    return items

--- a/Orange/widgets/classify/owclassificationtree.py
+++ b/Orange/widgets/classify/owclassificationtree.py
@@ -66,7 +66,7 @@ class OWClassificationTree(widget.OWWidget):
 
     def send_report(self):
         from Orange.canvas.report import plural_w
-        self.report_settings(
+        self.report_items(
             "Model parameters",
             [("Split selection", self.scores[self.attribute_score][0]),
              ("Pruning", ", ".join(s for s, c in (

--- a/Orange/widgets/data/owcontinuize.py
+++ b/Orange/widgets/data/owcontinuize.py
@@ -128,7 +128,7 @@ class OWContinuize(widget.OWWidget):
     def send_report(self):
         if self.data is not None:
             self.report_data("Input data", self.data)
-        self.report_settings(
+        self.report_items(
             "Settings",
             [("Multinominal attributes",
               self.multinomial_treats[self.multinomial_treatment][0]),

--- a/Orange/widgets/data/owdatasampler.py
+++ b/Orange/widgets/data/owdatasampler.py
@@ -209,7 +209,7 @@ class OWDataSampler(widget.OWWidget):
                 ("Sample", "{} instances".format(self.sampled_instances)),
                 ("Remaining", "{} instances".format(self.remaining_instances)),
             ]
-        self.report_settings("", items)
+        self.report_items("", items)
 
 
 def sample_fold_indices(table, folds=10, stratified=False, random_state=None):

--- a/Orange/widgets/data/owfile.py
+++ b/Orange/widgets/data/owfile.py
@@ -380,8 +380,8 @@ class OWFile(widget.OWWidget):
             name = "~/" + self.loaded_file[len(home):].lstrip("/").lstrip("\\")
         else:
             name = self.loaded_file
-        self.report_settings("File", [("File name", name),
-                                      ("Format", self._get_ext_name(name))])
+        self.report_items("File", [("File name", name),
+                                   ("Format", self._get_ext_name(name))])
         self.report_data("Data", self.data)
 
     def _get_ext_name(self, filename):

--- a/Orange/widgets/data/owpaintdata.py
+++ b/Orange/widgets/data/owpaintdata.py
@@ -1198,7 +1198,7 @@ class OWPaintData(widget.OWWidget):
         if self.attr1 != "x" or self.attr2 != "y":
             settings += [("Axis x", self.attr1), ("Axis y", self.attr2)]
         settings += [("Number of points", len(self.data))]
-        self.report_settings("Painted data", settings)
+        self.report_items("Painted data", settings)
         self.report_plot("", self.plot)
 
 def test():

--- a/Orange/widgets/data/owrank.py
+++ b/Orange/widgets/data/owrank.py
@@ -14,6 +14,7 @@ from PyQt4.QtCore import Qt
 import Orange
 from Orange.data import ContinuousVariable, DiscreteVariable
 from Orange.preprocess import score
+from Orange.canvas import report
 from Orange.widgets import widget, settings, gui
 
 
@@ -64,7 +65,7 @@ class OWRank(widget.OWWidget):
 
     def __init__(self):
         super().__init__()
-        self.output_data_description = "None"
+        self.out_domain_desc = None
 
         self.all_measures = SCORES
 
@@ -423,21 +424,24 @@ class OWRank(widget.OWWidget):
         )
 
     def send_report(self):
-        self.report_data("Input data", self.data)
+        if not self.data:
+            return
+        self.report_domain("Input domain", self.data.domain)
         self.report_table("Ranks", self.ranksView, num_format="{:.3f}")
-        self.report_raw("Output data", self.output_data_description)
+        if self.out_domain_desc is not None:
+            self.report_items("Output domain", self.out_domain_desc)
 
     def commit(self):
         selected = self.selectedAttrs()
         if not self.data or not selected:
             self.send("Reduced Data", None)
-            self.output_data_description = "None"
+            self.out_domain_desc = None
         else:
             domain = Orange.data.Domain(selected, self.data.domain.class_var,
                                         metas=self.data.domain.metas)
             data = Orange.data.Table(domain, self.data)
             self.send("Reduced Data", data)
-            self.output_data_description = self.describe_data(data)
+            self.out_domain_desc = report.describe_domain(data.domain)
 
     def selectedAttrs(self):
         if self.data:

--- a/Orange/widgets/data/owselectcolumns.py
+++ b/Orange/widgets/data/owselectcolumns.py
@@ -666,7 +666,7 @@ class OWSelectAttributes(widget.OWWidget):
                         set(out_domain.variables + out_domain.metas))
             if diff:
                 text = "%i (%s)" % (len(diff), ", ".join(x.name for x in diff))
-                self.report_settings("", [("Removed", text)])
+                self.report_items("", [("Removed", text)])
 
 
 def test_main(argv=None):

--- a/Orange/widgets/evaluate/owtestlearners.py
+++ b/Orange/widgets/evaluate/owtestlearners.py
@@ -537,7 +537,7 @@ class OWTestLearners(widget.OWWidget):
         if self.data.domain.has_discrete_class:
             items += [("Target class", self.class_selection.strip("()"))]
         if items:
-            self.report_settings("Settings", items)
+            self.report_items("Settings", items)
         self.report_table("Scores", self.view)
 
 def learner_name(learner):

--- a/Orange/widgets/widget.py
+++ b/Orange/widgets/widget.py
@@ -17,9 +17,7 @@ from pyqtgraph import PlotWidget, PlotItem
 from Orange.data import Table
 from Orange.widgets import settings, gui
 from Orange.canvas.registry import description as widget_description
-from Orange.canvas.report import (clipped_list, get_html_section,
-                                  get_html_subsection, render_items,
-                                  get_html_img)
+from Orange.canvas import report
 from Orange.widgets.gui import ControlledAttributesDict, notify_changed
 from Orange.widgets.settings import SettingsHandler
 
@@ -261,88 +259,44 @@ class OWWidget(QDialog, metaclass=WidgetMetaClass):
         report.raise_()
 
     def create_report_html(self):
-        self.report_html = get_html_section(self.name)
+        self.report_html = report.get_html_section(self.name)
         self.send_report()
 
     def send_report(self):
         if hasattr(self, "data") and isinstance(self.data, Table):
             self.report_data("Data", self.data)
-        if hasattr(self, "canvas"):
-            self.report_plot("", self.canvas)
-        if hasattr(self, "box_scene"):
-            self.report_plot("", self.box_scene)
-        if hasattr(self, "plot"):
-            self.report_plot("", self.plot)
+        for attr in ("canvas", "box_scene", "plot"):
+            if hasattr(self, attr):
+                self.report_plot("", getattr(self, attr))
 
-    def report_settings(self, name, items):
+    def report_items(self, name, items, order=None, exclude=None):
         self.report_name(name)
-        self.report_html += render_items(items)
+        self.report_html += report.render_items(items, order, exclude)
 
     def report_name(self, name):
         if name != "":
-            self.report_html += get_html_subsection(name)
+            self.report_html += report.get_html_subsection(name)
 
-    def describe_data(self, data):
-        def clip_attrs(items, s):
-            r = clipped_list(a.name for a in items)
-            if len(items) > 10:
-                r += " (total: {} {})".format(len(items), s)
-            return r
+    def report_data(self, name, data, order=None, exclude=None):
+        self.report_items(name, report.describe_data(data),
+                          order=order, exclude=exclude)
 
-        if data is None:
-            return "No data."
-        else:
-            items = [
-                ("Data instances", len(data)),
-                ("Features", clip_attrs(data.domain.attributes, "features"))]
-            if data.domain.metas:
-                items.append(
-                    ("Meta attributes",
-                     clip_attrs(data.domain.metas, "meta attributes")))
-            if data.domain.class_vars:
-                items.append(
-                    ("Target",
-                     clip_attrs(data.domain.class_vars, "targets variables")))
-            return render_items(items)
+    def report_domain(self, name, domain, order=None, exclude=None):
+        self.report_items(name, report.describe_domain(domain),
+                          order=order, exclude=exclude)
 
-    def report_data(self, name, data):
-        self.report_name(name)
-        self.report_html += self.describe_data(data)
-
-    def describe_data_brief_items(self, data):
-        domain = data.domain
-        items = [
-            ("Data instances", len(data)),
-            ("Features", len(domain.attributes) or "None"),
-            ("Meta attributes", len(domain.metas) or "None")]
-        if domain.has_discrete_class:
-            items += [("Target",
-                       "Discrete class '{}'".format(data.domain.class_var.name))
-                      ]
-        elif domain.has_continuous_class:
-            items += [("Target",
-                       "Numeric variable '{}'".format(data.domain.class_var.name
-                                                      ))]
-        elif domain.class_vars:
-            items += [("Targets", len(domain.class_vars))]
-        return items
-
-    def describe_data_brief(self, data):
-        items = self.describe_data_brief_items(data)
-        return render_items(items)
-
-    def report_data_brief(self, name, data):
-        items = self.describe_data_brief_items(data)
-        self.report_settings(name, items)
+    def report_data_brief(self, name, data, order=None, exclude=None):
+        self.report_items(name, report.describe_data_brief(data),
+                          order=order, exclude=exclude)
 
     def report_plot(self, name, plot):
         self.report_name(name)
         if isinstance(plot, QGraphicsScene):
-            self.report_html += get_html_img(plot)
+            self.report_html += report.get_html_img(plot)
         elif isinstance(plot, PlotItem):
-            self.report_html += get_html_img(plot.scene())
+            self.report_html += report.get_html_img(plot.scene())
         elif isinstance(plot, PlotWidget):
-            self.report_html += get_html_img(plot.plotItem.scene())
+            self.report_html += report.get_html_img(plot.plotItem.scene())
 
     # noinspection PyBroadException
     def report_table(self, name, table, header_rows=0, header_columns=0,
@@ -413,7 +367,7 @@ class OWWidget(QDialog, metaclass=WidgetMetaClass):
         def report_abstract_model(model):
             content = (model.data(model.index(row, 0))
                        for row in range(model.rowCount()))
-            return clipped_list(content, limit, less_lookups=True)
+            return report.clipped_list(content, limit, less_lookups=True)
 
         self.report_name(name)
         try:


### PR DESCRIPTION
`describe_*` functions now return OrderedDict for easier handling, and `render_items` are more flexible. I also refactored other stuff to get a more coherent interface.

I saw you also moved some `OWReport` methods to the `report` module, as we discussed in the afternoon. I rebased it to your current commit, so you should be able to merge without any conflicts.
