### PR TITLE
Show colors and renames

### DIFF
--- a/Orange/canvas/report/report.py
+++ b/Orange/canvas/report/report.py
@@ -627,6 +627,9 @@ def describe_data_brief(data):
     items.update(describe_domain_brief(data.domain))
     return items
 
+def colored_square(r, g, b):
+    return '<span class="legend-square" ' \
+           'style="background-color: rgb({}, {}, {})"></span>'.format(r, g, b)
 
 def list_legend(model, selected=None):
     """
@@ -654,8 +657,6 @@ def list_legend(model, selected=None):
         r, g, b, a = QColor(
             icon.pixmap(12, 12).toImage().pixel(0, 0)).getRgb()
         text = model.data(index, Qt.DisplayRole)
-        legend += '<span class="legend-square" ' \
-                  'style="background-color: rgb({}, {}, {})"></span>' \
-                  '<span class="legend-item">{}</span>'.format(
-                      r, g, b, text)
+        legend += colored_square(r, g, b) + \
+                  '<span class="legend-item">{}</span>'.format(text)
     return legend

--- a/Orange/widgets/data/owcolor.py
+++ b/Orange/widgets/data/owcolor.py
@@ -237,6 +237,7 @@ class OWColor(widget.OWWidget):
     def __init__(self):
         super().__init__()
         self.data = None
+        self.orig_domain = None
         self.disc_colors = []
         self.cont_colors = []
 
@@ -280,7 +281,7 @@ class OWColor(widget.OWWidget):
                     vars.append(var)
                 return vars
 
-            domain = data.domain
+            domain = self.orig_domain = data.domain
             domain = Orange.data.Domain(create_part(domain.attributes),
                                         create_part(domain.class_vars),
                                         create_part(domain.metas))
@@ -323,17 +324,62 @@ class OWColor(widget.OWWidget):
         self.send("Data", self.data)
 
     def send_report(self):
+        def report_variables(variables, orig_variables):
+            from Orange.canvas.report import colored_square as square
+
+            def was(n, o):
+                return n if n == o else "{} (was: {})".format(n, o)
+
+            # definition of td element for continuous gradient
+            # with support for pre-standard css (needed at least for Qt 4.8)
+            max_values = max(
+                (len(var.values) for var in variables if var.is_discrete),
+                default=1)
+            defs = ("-webkit-", "-o-", "-moz-", "")
+            cont_tpl = '<td colspan="{}">' \
+                       '<span class="legend-square" style="width: 100px; '.\
+                format(max_values) + \
+                " ".join(map(
+                    "background: {}linear-gradient("
+                    "right, rgb({{}}, {{}}, {{}}), {{}}rgb({{}}, {{}}, {{}}));"
+                    .format, defs)) + \
+                '"></span></td>'
+
+            rows = ""
+            for var, ovar in zip(variables, orig_variables):
+                if var.is_discrete:
+                    values = "    \n".join(
+                        "<td>{} {}</td>".
+                        format(square(*var.colors[i]), was(value, ovalue))
+                        for i, (value, ovalue) in
+                        enumerate(zip(var.values, ovar.values)))
+                elif var.is_continuous:
+                    col = var.colors
+                    colors = col[0][:3] + ("black, " * col[2], ) + col[1][:3]
+                    values = cont_tpl.format(*colors * len(defs))
+                else:
+                    continue
+                name = was(var.name, ovar.name)
+                rows += '<tr style="height: 2em">\n' \
+                        '  <th style="text-align: right">{}</th>{}\n</tr>\n'. \
+                    format(name, values)
+            return rows
+
         if not self.data:
             return
-        disc_vars = [var.name for var in self.disc_colors if "colors" in
-                     var.attributes and var.colors is not False]
-        cont_vars = [var.name for var in self.cont_colors if "colors" in
-                     var.attributes and var.colors is not False]
-        disc_text = ", ".join(disc_vars) if len(disc_vars) else "No changes."
-        cont_text = ", ".join(cont_vars) if len(cont_vars) else "No changes."
-        self.report_domain("Data", self.data.domain)
-        self.report_items("Changed variables",
-                          (("Discrete", disc_text), ("Numeric", cont_text)))
+        domain = self.data.domain
+        orig_domain = self.orig_domain
+        sections = (
+            (name, report_variables(vars, ovars))
+            for name, vars, ovars in (
+                ("Features", domain.attributes, orig_domain.attributes),
+                ("Outcome" + "s" * (len(domain.class_vars) > 1),
+                    domain.class_vars, orig_domain.class_vars),
+                ("Meta attributes", domain.metas, orig_domain.metas)))
+        table = "".join("<tr><th>{}</th></tr>{}".format(name, rows)
+                        for name, rows in sections if rows)
+        if table:
+            self.report_raw("<table>{}</table>".format(table))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Instead of just listing the variables with redefined colors, show the actual colors (for all variables) and indicate which variable and value names have been renamed by the widget.
